### PR TITLE
Add hint about using Artisan via Sail

### DIFF
--- a/resources/docs/installation.md
+++ b/resources/docs/installation.md
@@ -57,6 +57,7 @@ cd chirper
 
 ```shell
 ./vendor/bin/sail php --version
+./vendor/bin/sail artisan --version
 ./vendor/bin/sail composer --version
 ./vendor/bin/sail npm --version
 ```


### PR DESCRIPTION
Commit [#1acdc5b](https://github.com/laravel/bootcamp.laravel.com/commit/1acdc5b051c8941e647f9c6b7de2c0b67a13efda) replaces all the instances of `./vendor/bin/sail artisan` with `php artisan`, so a mention of `sail artisan` might be useful for those sticking with sail.