### PR TITLE
Update development server links

### DIFF
--- a/resources/docs/creating-chirps.md
+++ b/resources/docs/creating-chirps.md
@@ -183,7 +183,7 @@ class ChirpController extends Controller
 }
 ```
 
-If you are still logged in from earlier, you should see your message when navigating to [http://localhost/chirps](http://localhost/chirps)!
+If you are still logged in from earlier, you should see your message when navigating to [http://localhost:8000/chirps](http://localhost:8000/chirps), or [http://localhost/chirps](http://localhost/chirps) if you're using Sail!
 
 ## Inertia
 
@@ -353,7 +353,7 @@ export default function Index({ auth }) {
 }
 ```
 
-That's it! Refresh the page at [http://localhost/chirps](http://localhost/chirps) and you should see your new form rendered in the default layout provided by Breeze!
+That's it! Refresh the page in your browser to see your new form rendered in the default layout provided by Breeze!
 
 <img src="/img/screenshots/chirp-form.png" alt="Chirp form" class="rounded-lg border dark:border-none shadow-lg" />
 
@@ -668,7 +668,7 @@ php artisan migrate
 
 ## Testing it out
 
-We're now ready to send a Chirp from the form we added to [http://localhost/chirps](http://localhost/chirps)! You won't be able to see the result yet because we haven't displayed existing Chirps on the page.
+We're now ready to send a Chirp using the form we just added! We won't be able to see the result yet because we haven't displayed existing Chirps on the page.
 
 <img src="/img/screenshots/chirp-form-filled.png" alt="Chirp form" class="rounded-lg border dark:border-none shadow-lg" />
 

--- a/resources/docs/creating-chirps.md
+++ b/resources/docs/creating-chirps.md
@@ -357,7 +357,7 @@ That's it! Refresh the page in your browser to see your new form rendered in the
 
 <img src="/img/screenshots/chirp-form.png" alt="Chirp form" class="rounded-lg border dark:border-none shadow-lg" />
 
-Now that our front-end is powered by JavaScript, any changes we make to our JavaScript templates will be automatically reloaded in the browser when the Vite development server is running.
+Now that our front-end is powered by JavaScript, any changes we make to our JavaScript templates will be automatically reloaded in the browser whenever the Vite development server is running via `npm run dev`.
 
 ## Navigation menu
 
@@ -670,7 +670,7 @@ php artisan migrate
 
 ## Testing it out
 
-We're now ready to send a Chirp using the form we just added! We won't be able to see the result yet because we haven't displayed existing Chirps on the page.
+We're now ready to send a Chirp using the form we just created! We won't be able to see the result yet because we haven't displayed existing Chirps on the page.
 
 <img src="/img/screenshots/chirp-form-filled.png" alt="Chirp form" class="rounded-lg border dark:border-none shadow-lg" />
 

--- a/resources/docs/creating-chirps.md
+++ b/resources/docs/creating-chirps.md
@@ -357,6 +357,8 @@ That's it! Refresh the page in your browser to see your new form rendered in the
 
 <img src="/img/screenshots/chirp-form.png" alt="Chirp form" class="rounded-lg border dark:border-none shadow-lg" />
 
+Now that our front-end is powered by JavaScript, any changes we make to our JavaScript templates will be automatically reloaded in the browser when the Vite development server is running.
+
 ## Navigation menu
 
 Let's take a moment to add a link to the navigation menu provided by Breeze.

--- a/resources/docs/installation.md
+++ b/resources/docs/installation.md
@@ -22,6 +22,9 @@ php artisan serve
 
 Once you have started the Artisan development server, your application will be accessible in your web browser at [http://localhost:8000](http://localhost:8000).
 
+<img src="/img/screenshots/fresh.png" alt="A fresh Laravel installation" class="dark:hidden rounded-lg border shadow-lg" />
+<img src="/img/screenshots/fresh-dark.png" alt="A fresh Laravel installation" class="hidden dark:block rounded-lg border-gray-700 shadow-lg" />
+
 For simplicity, you may use SQLite to store your application's data. To instruct Laravel to use SQLite instead of MySQL, update your new application's `.env` file and remove all of the `DB_*` environment variables except for the `DB_CONNECTION` variable, which should be set to `sqlite`:
 
 ```ini

--- a/resources/docs/installation.md
+++ b/resources/docs/installation.md
@@ -98,7 +98,7 @@ Finally, open another terminal in your `chirper` project directory and run the i
 php artisan migrate
 ```
 
-If you refresh your new Laravel application in the browser at [http://localhost](http://localhost), you should now see a "Register" link at the top-right. Follow that to see the registration form provided by Laravel Breeze.
+If you refresh your new Laravel application in the browser, you should now see a "Register" link at the top-right. Follow that to see the registration form provided by Laravel Breeze.
 
 <img src="/img/screenshots/register.png" alt="Laravel registration page" class="rounded-lg border dark:border-none shadow-lg" />
 

--- a/resources/docs/installation.md
+++ b/resources/docs/installation.md
@@ -20,7 +20,7 @@ cd chirper
 php artisan serve
 ```
 
-Once you have started the Artisan development server, your application will be accessible in your web browser at `http://localhost:8000`.
+Once you have started the Artisan development server, your application will be accessible in your web browser at [http://localhost:8000](http://localhost:8000).
 
 For simplicity, you may use SQLite to store your application's data. To instruct Laravel to use SQLite instead of MySQL, update your new application's `.env` file and remove all of the `DB_*` environment variables except for the `DB_CONNECTION` variable, which should be set to `sqlite`:
 

--- a/resources/docs/showing-chirps.md
+++ b/resources/docs/showing-chirps.md
@@ -281,7 +281,7 @@ export default function Index({ auth, chirps }) {// [tl! add]
 }
 ```
 
-Refresh the page at [http://localhost/chirps](http://localhost/chirps) to see the message you Chirped earlier!
+Now take a look in your browser to see the message you Chirped earlier!
 
 <img src="/img/screenshots/chirp-index.png" alt="Chirp listing" class="rounded-lg border dark:border-none shadow-lg" />
 


### PR DESCRIPTION
Now that the user has a choice of `artisan serve` or Sail, this PR updates any references to the Sail-specific URL to either mention both, or remove it where possible.

This PR also:
* Makes the `artisan serve` URL a link to allow easy navigation to it.
* Copies the screenshot from the Docker section to the Quick Start section.
* Adds some text after we first load the page with Vue/React to mention the automatic reloading via Vite.