### PR TITLE
Fix cubes making navigation link unreachable

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -28,14 +28,15 @@
                             </div>
                         </nav>
                     </div>
-
-                    @if ($page !== 'introduction')
-                        <div class="hidden 2xl:block absolute bottom-0 mb-12 pl-16">
-                            <x-cube delay="0" class="ml-8" />
-                            <x-cube delay="2000" class="mt-6 ml-32" />
-                            <x-cube delay="1000" class="mt-12" />
-                        </div>
-                    @endif
+                    <div class="flex-grow flex flex-col justify-end">
+                        @if ($page !== 'introduction')
+                            <div class="hidden 2xl:block mb-12 pl-16">
+                                <x-cube delay="0" class="ml-8" />
+                                <x-cube delay="2000" class="mt-6 ml-32" />
+                                <x-cube delay="1000" class="mt-12" />
+                            </div>
+                        @endif
+                    </div>
                 </div>
             </aside>
 


### PR DESCRIPTION
Floating cubes at the bottom of navigation making navigation links unreachable.

![image](https://user-images.githubusercontent.com/29161993/193743366-3fc64851-a61d-48a4-8ce3-c6a5a430224c.png)

As shown in above picture, Deploying and Conclusion links are not reachable for those floating cubes.

I pushed floating blocks below to the navigation links and still stick to bottom as previously was.

![image](https://user-images.githubusercontent.com/29161993/193743916-beae5086-ee8a-4f9e-83ec-2a485eb50cff.png)
