### PR TITLE
Fix styling overflow-wrap for `<code />` element

### DIFF
--- a/resources/css/_code.css
+++ b/resources/css/_code.css
@@ -15,6 +15,10 @@ pre code.torchlight .summary-caret {
     @apply mr-1;
 }
 
+code {
+    @apply break-words;
+}
+
 .tabbed-code {
     @apply my-5 bg-dark-500 rounded-md overflow-hidden;
 


### PR DESCRIPTION
## Issue

When we open the website in mobile, there is bug in code element, like this:

![Screenshot 2022-10-20 045631](https://user-images.githubusercontent.com/39640211/196813029-1149428e-c869-4340-b812-ae120ebbea2b.png)

## Changes

- Set overflow-wrap for `<code />` to break-word

  ![Screenshot 2022-10-20 045731](https://user-images.githubusercontent.com/39640211/196813234-8fc7e783-b6a4-4d50-b2fe-d2965a70b549.png)
