### PR TITLE
Update for Specify the recommended php version

### DIFF
--- a/resources/docs/inertia/installation.md
+++ b/resources/docs/inertia/installation.md
@@ -8,6 +8,10 @@
 
 If you have already installed PHP and Composer on your local machine, you may create a new Laravel project via Composer:
 
+> **Note**
+> We recommend using PHP 8.0 or higher to run this document without problems.   
+> If you are using a version earlier than 8.0, we recommend that you try the installation method through docker described below.
+
 ```shell
 composer create-project laravel/laravel chirper
 ```


### PR DESCRIPTION
Yesterday I try this with php 7.4 and problem install breeze. Because if use php 8.0 below, composer will install laravel 8. I was spend lot time for this, so I try to know who try install first time.

![image](https://user-images.githubusercontent.com/29521447/201807080-431ee600-9904-491b-99e6-fe65869cf739.png)

Acatually this problem is not match laravel 8 and "laravel/breeze": "^1.10",

Fianlly I soved  with laravel/breeze:1.9.4

But this is complicate so I just want notice to people, Recommand use more high 8.0 version.

Thank you for great project.
