### PR TITLE
Enabled Torchlight visual difference indicators

### DIFF
--- a/config/torchlight.php
+++ b/config/torchlight.php
@@ -53,7 +53,7 @@ return [
         // 'lineNumbersStyle' => '',
 
         // Turn on +/- diff indicators.
-        'diffIndicators' => false,
+        'diffIndicators' => true,
 
         // Preserve syntax colors in diffs.
         'diffPreserveSyntaxColors' => true,


### PR DESCRIPTION
Enabled visual difference indicators in Torchlight config file to increase visual accessibility (re: [this Discord post](https://discord.com/channels/297040613688475649/1060586040353620139))