### PR TITLE
Fix Chirp model reference in Tinker example

### DIFF
--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -633,7 +633,7 @@ php artisan tinker
 Next, execute the following code to display the Chirps in your database:
 
 ```shell
-Chirp::all();
+App\Models\Chirp::all();
 ```
 
 ```


### PR DESCRIPTION
Running `Chirp::all()` with Sail I am getting "Class "Chirp" not found.". If I change to `App\Models\Chirp::all()` it works

Let me know if I am just doing something wrong here.