### PR TITLE
Modified to use PrimaryButton disabled in Chirps/Index.jsx

### DIFF
--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -309,7 +309,7 @@ export default function Index({ auth }) {
                         onChange={e => setData('message', e.target.value)}
                     ></textarea>
                     <InputError message={errors.message} className="mt-2" />
-                    <PrimaryButton className="mt-4" processing={processing}>Chirp</PrimaryButton>
+                    <PrimaryButton className="mt-4" disabled={processing}>Chirp</PrimaryButton>
                 </form>
             </div>
         </AuthenticatedLayout>


### PR DESCRIPTION
Processing is not present in the PrimaryButton props. I expect that it is probably disabled here, not processing.