### PR TITLE
Fix creating-chirps.md

### DIFF
--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -297,7 +297,7 @@ export default function Index({ auth }) {
     };
 
     return (
-        <AuthenticatedLayout auth={auth}>
+        <AuthenticatedLayout user={auth.user}>
             <Head title="Chirps" />
 
             <div className="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">


### PR DESCRIPTION
# Issue
While following [the creating chirps example on Laravel Bootcamp](https://bootcamp.laravel.com/inertia/creating-chirps#inertia), the error below is thrown after generating and navigating to the **Chirps/Index** page component. This issue is specific to the React example provided in the Laravel Bootcamp docs.

<img width="420" alt="Screenshot 2023-04-23 at 1 32 29 AM" src="https://user-images.githubusercontent.com/28225474/233814631-b7e413cb-fb68-43e5-8874-95d1db633f7d.png">

# Why Does the Issue Occur?
<img width="1412" alt="Screenshot 2023-04-23 at 1 34 13 AM" src="https://user-images.githubusercontent.com/28225474/233815224-dd365238-982f-4fb0-ac5c-048ae88f85ef.png">

The issue occurs because, whereas the React example on Laravel Bootcamp passes an `auth` prop to the `AuthenticatedLayout` component, [the underlying implementation for `AuthenticatedLayout` in Laravel Breeze](https://github.com/laravel/breeze/blob/1.x/stubs/inertia-react/resources/js/Layouts/AuthenticatedLayout.jsx#L8) has no `auth` prop, but requires a `user` prop instead.

<img width="1411" alt="Screenshot 2023-04-23 at 3 01 45 AM" src="https://user-images.githubusercontent.com/28225474/233815439-d346ba80-40f8-4929-bbdc-af7c35dd8f43.png">

This is the reason why the `name` property of the `user` object is inaccessible because `user` is `undefined`.

# Issue Fixes
- Changed the prop passed to `AuthenticatedLayout` React component in creating-chirps.md to match expected prop.