### PR TITLE
Fixed a usage example of tinker

### DIFF
--- a/resources/docs/blade/creating-chirps.md
+++ b/resources/docs/blade/creating-chirps.md
@@ -543,6 +543,7 @@ php artisan tinker
 Next, execute the following code to display the Chirps in your database:
 
 ```shell
+use App\Models\Chirp;
 Chirp::all();
 ```
 


### PR DESCRIPTION
Output before fix:

```
> Chirp::all();

   Error  Class "Chirp" not found.
```

Output after fix:

```
> use App\Models\Chirp;
> Chirp::all();
= Illuminate\Database\Eloquent\Collection {#7191
    all: [
      App\Models\Chirp {#7193
        id: 1,
        user_id: 1,
        message: "hello",
        created_at: "2023-05-04 09:54:55",
        updated_at: "2023-05-04 09:54:55",
      },
    ],
  }
```
