### PR TITLE
Fix class to className in React code

### DIFF
--- a/resources/docs/inertia/deleting-chirps.md
+++ b/resources/docs/inertia/deleting-chirps.md
@@ -369,7 +369,7 @@ export default function Chirp({ chirp }) {
                 {editing
                     ? <form onSubmit={submit}>
                         <textarea value={data.message} onChange={e => setData('message', e.target.value)} className="mt-4 w-full text-gray-900 border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm"></textarea>
-                        <InputError message={errors.message} class="mt-2" />
+                        <InputError message={errors.message} className="mt-2" />
                         <div className="space-x-2">
                             <PrimaryButton className="mt-4">Save</PrimaryButton>
                             <button className="mt-4" onClick={() => setEditing(false) && reset()}>Cancel</button>

--- a/resources/docs/inertia/editing-chirps.md
+++ b/resources/docs/inertia/editing-chirps.md
@@ -186,7 +186,7 @@ export default function Chirp({ chirp }) {
                 {editing
                     ? <form onSubmit={submit}>
                         <textarea value={data.message} onChange={e => setData('message', e.target.value)} className="mt-4 w-full text-gray-900 border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm"></textarea>
-                        <InputError message={errors.message} class="mt-2" />
+                        <InputError message={errors.message} className="mt-2" />
                         <div className="space-x-2">
                             <PrimaryButton className="mt-4">Save</PrimaryButton>
                             <button className="mt-4" onClick={() => { setEditing(false); reset(); clearErrors(); }}>Cancel</button>


### PR DESCRIPTION
It is correct to use className instead of class in React code.

Class was used in the following two places.

```console
> find . -type f -name "*.md" -print0 | xargs -0 -I{} awk '/^```javascript tab=React/,/^```$/{print FILENAME ":" FNR ":" $0}' {} | grep 'class='
./resources/docs/inertia/deleting-chirps.md:372:                        <InputError message={errors.message} class="mt-2" />
./resources/docs/inertia/editing-chirps.md:189:                        <InputError message={errors.message} class="mt-2" />
```