### PR TITLE
Fix pages overflow

### DIFF
--- a/resources/css/_code.css
+++ b/resources/css/_code.css
@@ -15,6 +15,10 @@ pre code.torchlight .summary-caret {
     @apply mr-1;
 }
 
+p code {
+    @apply inline-flex max-w-full overflow-scroll
+}
+
 .tabbed-code {
     @apply my-5 bg-dark-500 rounded-md overflow-hidden;
 

--- a/resources/css/_code.css
+++ b/resources/css/_code.css
@@ -17,11 +17,7 @@ pre code.torchlight .summary-caret {
 
 li code,
 p code {
-    @apply inline-flex max-w-full overflow-scroll
-}
-
-table {
-    @apply block max-w-full overflow-scroll
+    @apply break-words;
 }
 
 .tabbed-code {

--- a/resources/css/_code.css
+++ b/resources/css/_code.css
@@ -15,8 +15,13 @@ pre code.torchlight .summary-caret {
     @apply mr-1;
 }
 
+li code,
 p code {
     @apply inline-flex max-w-full overflow-scroll
+}
+
+table {
+    @apply block max-w-full overflow-scroll
 }
 
 .tabbed-code {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -41,3 +41,8 @@ h1 b {
     @apply text-red-600;
     font-weight: inherit;
 }
+
+/* Responsive tables */
+table {
+    @apply block max-w-full overflow-auto
+}


### PR DESCRIPTION
## Summary

This PR is a continuation of #14 keeping the code element inline and also applying the change reviewed by @jessarcher to make the CSS selectors more explicit.

I've tried all pages to look for more overflow issues and I found at least two pages that the tables were also overflowing, I applied similar tailwind properties to solve it as well.

## Demonstration

### :x: Before the changes

![before_bladeediting-chirps](https://github.com/laravel/bootcamp.laravel.com/assets/43862225/2645779f-397e-4995-a3e0-f2bf649125c4)


![before-bladecreating-chirps](https://github.com/laravel/bootcamp.laravel.com/assets/43862225/a43a552b-93de-4acd-be39-74858e37c347)

### ✔ After the changes

![bladeediting-chirps](https://github.com/laravel/bootcamp.laravel.com/assets/43862225/65ed8289-b43b-4838-b77b-eabbc0ff795c)

![bladecreating-chirps](https://github.com/laravel/bootcamp.laravel.com/assets/43862225/54d510bf-9b9c-4d50-b6dc-6cc0186b90ab)

## Breakdown

```css
li code,
p code {
    @apply inline-flex max-w-full overflow-scroll
}

table {
    @apply block max-w-full overflow-scroll
}
```

`inline-flex` or `display: inline-flex` is similar to `display: inline-block` but using the `flex` property. Unfortunately I didn't understood quite well so here is the [link](https://stackoverflow.com/questions/27418104/whats-the-difference-between-displayinline-flex-and-displayflex) for more info about it. I had to use it instead of `inline-block` because it was displaying a slightly different positioning on the code elements.

`max-w-full` or `max-width: 100%` is going to allow the code element to occupy all of its parent width, making it possible for the next attribute to control the overflow.

`overflow-scroll` or `overflow: scroll` will detect if the content is trying to go beyond its parent's width and add scroll bars to it.
