### PR TITLE
fix: changed migration directory name to migrations

### DIFF
--- a/resources/docs/blade/creating-chirps.md
+++ b/resources/docs/blade/creating-chirps.md
@@ -480,7 +480,7 @@ You can learn more about Laravel's mass assignment protection in the [documentat
 
 The only thing missing is extra columns in our database to store the relationship between a `Chirp` and its `User` and the message itself. Remember the database migration we created earlier? It's time to open that file to add some extra columns:
 
-```php filename=databases/migration/&amp;lt;timestamp&amp;gt;_create_chirps_table.php
+```php filename=databases/migrations/&amp;lt;timestamp&amp;gt;_create_chirps_table.php
 <?php
 // [tl! collapse:start]
 use Illuminate\Database\Migrations\Migration;

--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -570,7 +570,7 @@ You can learn more about Laravel's mass assignment protection in the [documentat
 
 The only thing missing is extra columns in our database to store the relationship between a `Chirp` and its `User` and the message itself. Remember the database migration we created earlier? It's time to open that file to add some extra columns:
 
-```php filename=databases/migration/&amp;lt;timestamp&amp;gt;_create_chirps_table.php
+```php filename=databases/migrations/&amp;lt;timestamp&amp;gt;_create_chirps_table.php
 <?php
 // [tl! collapse:start]
 use Illuminate\Database\Migrations\Migration;


### PR DESCRIPTION
When to explain how to update the migration file in both (inertia and blade tutorials), the directory name is wrong. The correct name to migration files is `migrations`.

Follow the image on both cases:
*Blade tutorial:*
<img width="1095" alt="Screenshot 2023-08-02 at 21 01 16" src="https://github.com/laravel/bootcamp.laravel.com/assets/16943171/59e800e9-6c20-4def-86f5-52ce9d6de80c">

*Inertia tutorial:*
<img width="985" alt="Screenshot 2023-08-02 at 21 00 33" src="https://github.com/laravel/bootcamp.laravel.com/assets/16943171/e52241e4-77ff-4c08-9074-b4ac6b0d5a62">
