### PR TITLE
Update docs for Notifications and Events by adding `MAIL_HOST` value to `localhost`

### DIFF
--- a/resources/docs/notifications-and-events.md
+++ b/resources/docs/notifications-and-events.md
@@ -288,7 +288,7 @@ class EventServiceProvider extends ServiceProvider
 
 You may utilize local email testing tools like [Mailpit](https://github.com/axllent/mailpit) and [HELO](https://usehelo.com/) to catch any emails coming from your application so you may view them. If you are developing via Docker and Laravel Sail then Mailpit is included for you.
 
-Alternatively, you may configure Laravel to write mail to a log file by editing the `.env` file in your project and changing the `MAIL_MAILER` environment variable to `log`. By default, emails will be written to a log file located at `storage/logs/laravel.log`.
+Alternatively, you may configure Laravel to write mail to a log file by editing the `.env` file in your project and changing the `MAIL_MAILER` environment variable to `log` and `MAIL_HOST` to `localhost`. By default, emails will be written to a log file located at `storage/logs/laravel.log`.
 
 We've configured our notification not to send to the Chirp author, so be sure to register at least two users accounts. Then, go ahead and post a new Chirp to trigger a notification.
 


### PR DESCRIPTION
The `env` file comes by default with `mailpit` as the value for `MAIL_HOST`. 

Problem 1 - If we follow the instructions and only change the `MAIL_MAILER` to `log`, nothing will be logged into `laravel.log` because the `MAIL_HOST` is set to `mailpit`.

Problem 2- If we want to use `mailpit` we still want to change `MAIL_HOST` to `localhost` otherwise we will get the following error: `Connection could not be established with host "mailpit:1025": stream_socket_client(): php_network_getaddresses: getaddrinfo for mailpit failed: nodename nor servname provided, or not known`

I think the solution is to add `MAIL_HOST=localhost` into the documentation since the local machine cannot resolve the namespace.
  