### PR TITLE
Update creating-chirps.md

### DIFF
--- a/resources/docs/blade/creating-chirps.md
+++ b/resources/docs/blade/creating-chirps.md
@@ -543,6 +543,9 @@ php artisan tinker
 Next, execute the following code to display the Chirps in your database:
 
 ```shell
+use App\Models\Chirp;
+```
+```shell
 Chirp::all();
 ```
 


### PR DESCRIPTION
Without the `use App\Models\Chirp;` the output will be:
```shell
php artisan tinker
Psy Shell v0.11.21 (PHP 8.2.10 — cli) by Justin Hileman
> Chirp::all()

   Error  Class "Chirp" not found.
```

With the extra line, the expected output is shown.