### PR TITLE
Update creating-chirps.md

### DIFF
--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -633,8 +633,7 @@ php artisan tinker
 Next, execute the following code to display the Chirps in your database:
 
 ```shell
-use App\Models\Chirp;
-Chirp::all();
+App\Models\Chirp::all();
 ```
 
 ```

--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -633,6 +633,7 @@ php artisan tinker
 Next, execute the following code to display the Chirps in your database:
 
 ```shell
+use App\Models\Chirp;
 Chirp::all();
 ```
 


### PR DESCRIPTION
Add `use App\Models\Chirp;` to remove confusion and show requirements to call the Chirp class inside the REPL.