### PR TITLE
Fix display chirps in artisan tinker

### DIFF
--- a/resources/docs/blade/creating-chirps.md
+++ b/resources/docs/blade/creating-chirps.md
@@ -543,7 +543,7 @@ php artisan tinker
 Next, execute the following code to display the Chirps in your database:
 
 ```shell
-Chirp::all();
+App\Models\Chirp::all();
 ```
 
 ```

--- a/resources/docs/livewire/creating-chirps.md
+++ b/resources/docs/livewire/creating-chirps.md
@@ -474,7 +474,7 @@ php artisan tinker
 Next, execute the following code to display the Chirps in your database:
 
 ```shell
-Chirp::all();
+App\Models\Chirp::all();
 ```
 
 ```


### PR DESCRIPTION
This PR is repair the docs of how to get all the chirps via artisan Tinker in sections Build Chirper with Blade and Build Chirper with Livewire. Previously, if I run command `Chirp::all();` then Tinker will give error message **Class "Chirp" not found.** In order to make it works, I replace with command `App\Models\Chirp::all();`.