### PR TITLE
Fix Editing Chirper and Add Confirm Delete Chirper in Livewire

### DIFF
--- a/resources/docs/livewire/deleting-chirps.md
+++ b/resources/docs/livewire/deleting-chirps.md
@@ -48,7 +48,7 @@ new class extends Component
 
     #[On('chirp-edit-canceled')]
     #[On('chirp-updated')]
-    public function cancelEdit(): void
+    public function disableEdit(): void
     {
         $this->editing = null;
 
@@ -120,7 +120,7 @@ use function Livewire\Volt\{on, state};
 
 $getChirps = fn () => $this->chirps = Chirp::with('user')->latest()->get();
 
-$cancelEdit = function () {
+$disableEdit = function () {
     $this->editing = null;
 
     return $this->getChirps();
@@ -130,8 +130,8 @@ state(['chirps' => $getChirps, 'editing' => null]);
 
 on([
     'chirp-created' => $getChirps,
-    'chirp-updated' => $cancelEdit,
-    'chirp-edit-canceled' => $cancelEdit,
+    'chirp-updated' => $disableEdit,
+    'chirp-edit-canceled' => $disableEdit,
 ]);
 
 $edit = function (Chirp $chirp) {

--- a/resources/docs/livewire/deleting-chirps.md
+++ b/resources/docs/livewire/deleting-chirps.md
@@ -48,7 +48,7 @@ new class extends Component
 
     #[On('chirp-edit-canceled')]
     #[On('chirp-updated')]
-    public function disableEditing(): void
+    public function cancelEdit(): void
     {
         $this->editing = null;
 
@@ -120,7 +120,7 @@ use function Livewire\Volt\{on, state};
 
 $getChirps = fn () => $this->chirps = Chirp::with('user')->latest()->get();
 
-$disableEditing = function () {
+$cancelEdit = function () {
     $this->editing = null;
 
     return $this->getChirps();
@@ -130,8 +130,8 @@ state(['chirps' => $getChirps, 'editing' => null]);
 
 on([
     'chirp-created' => $getChirps,
-    'chirp-updated' => $disableEditing,
-    'chirp-edit-canceled' => $disableEditing,
+    'chirp-updated' => $cancelEdit,
+    'chirp-edit-canceled' => $cancelEdit,
 ]);
 
 $edit = function (Chirp $chirp) {

--- a/resources/docs/livewire/deleting-chirps.md
+++ b/resources/docs/livewire/deleting-chirps.md
@@ -32,11 +32,8 @@ new class extends Component
     }
 
     #[On('chirp-created')]
-    #[On('chirp-updated')]
     public function getChirps(): void
     {
-        $this->editing = null;
-
         $this->chirps = Chirp::with('user')
             ->latest()
             ->get();
@@ -45,12 +42,17 @@ new class extends Component
     public function edit(Chirp $chirp): void
     {
         $this->editing = $chirp;
+
+        $this->getChirps();
     }
 
     #[On('chirp-edit-canceled')]
-    public function cancelEdit(): void
+    #[On('chirp-updated')]
+    public function disableEditing(): void
     {
         $this->editing = null;
+
+        $this->getChirps();
     } // [tl! collapse:end]
     // [tl! add:start]
     public function delete(Chirp $chirp): void
@@ -116,21 +118,27 @@ new class extends Component
 use App\Models\Chirp;
 use function Livewire\Volt\{on, state};
 
-$getChirps = function () {
+$getChirps = fn () => $this->chirps = Chirp::with('user')->latest()->get();
+
+$disableEditing = function () {
     $this->editing = null;
 
-    return $this->chirps = Chirp::with('user')->latest()->get();
+    return $this->getChirps();
 };
 
 state(['chirps' => $getChirps, 'editing' => null]);
 
 on([
     'chirp-created' => $getChirps,
-    'chirp-updated' => $getChirps,
-    'chirp-edit-canceled' => fn () => $this->editing = null,
+    'chirp-updated' => $disableEditing,
+    'chirp-edit-canceled' => $disableEditing,
 ]);
 
-$edit = fn (Chirp $chirp) => $this->editing = $chirp; // [tl! collapse:end]
+$edit = function (Chirp $chirp) {
+    $this->editing = $chirp;
+
+    $this->getChirps();
+}; // [tl! collapse:end]
 // [tl! add:start]
 $delete = function (Chirp $chirp) {
     $this->authorize('delete', $chirp);

--- a/resources/docs/livewire/deleting-chirps.md
+++ b/resources/docs/livewire/deleting-chirps.md
@@ -93,7 +93,7 @@ new class extends Component
                                 <x-dropdown-link wire:click="edit({{ $chirp->id }})">
                                     {{ __('Edit') }}
                                 </x-dropdown-link>
-                                <x-dropdown-link wire:click="delete({{ $chirp->id }})"> <!-- [tl! add:start] -->
+                                <x-dropdown-link wire:click="delete({{ $chirp->id }})" wire:confirm="Are you sure to delete this chirp?"> <!-- [tl! add:start] -->
                                     {{ __('Delete') }}
                                 </x-dropdown-link> <!-- [tl! add:end] -->
                             </x-slot>
@@ -178,7 +178,7 @@ $delete = function (Chirp $chirp) {
                                 <x-dropdown-link wire:click="edit({{ $chirp->id }})">
                                     {{ __('Edit') }}
                                 </x-dropdown-link>
-                                <x-dropdown-link wire:click="delete({{ $chirp->id }})"> <!-- [tl! add:start] -->
+                                <x-dropdown-link wire:click="delete({{ $chirp->id }})" wire:confirm="Are you sure to delete this chirp?"> <!-- [tl! add:start] -->
                                     {{ __('Delete') }}
                                 </x-dropdown-link> <!-- [tl! add:end] -->
                             </x-slot>

--- a/resources/docs/livewire/deleting-chirps.md
+++ b/resources/docs/livewire/deleting-chirps.md
@@ -48,7 +48,7 @@ new class extends Component
 
     #[On('chirp-edit-canceled')]
     #[On('chirp-updated')]
-    public function disableEdit(): void
+    public function disableEditing(): void
     {
         $this->editing = null;
 
@@ -120,7 +120,7 @@ use function Livewire\Volt\{on, state};
 
 $getChirps = fn () => $this->chirps = Chirp::with('user')->latest()->get();
 
-$disableEdit = function () {
+$disableEditing = function () {
     $this->editing = null;
 
     return $this->getChirps();
@@ -130,8 +130,8 @@ state(['chirps' => $getChirps, 'editing' => null]);
 
 on([
     'chirp-created' => $getChirps,
-    'chirp-updated' => $disableEdit,
-    'chirp-edit-canceled' => $disableEdit,
+    'chirp-updated' => $disableEditing,
+    'chirp-edit-canceled' => $disableEditing,
 ]);
 
 $edit = function (Chirp $chirp) {

--- a/resources/docs/livewire/editing-chirps.md
+++ b/resources/docs/livewire/editing-chirps.md
@@ -42,6 +42,8 @@ new class extends Component
     public function edit(Chirp $chirp): void
     {
         $this->editing = $chirp;
+
+        $this->getChirps();
     } // [tl! add:end]
 }; ?>
 
@@ -102,7 +104,11 @@ state(['chirps' => $getChirps, 'editing' => null]); // [tl! add]
 
 on(['chirp-created' => $getChirps]);
 // [tl! add:start]
-$edit = fn (Chirp $chirp) => $this->editing = $chirp; // [tl! add:end]
+$edit = function (Chirp $chirp) {
+    $this->editing = $chirp;
+    
+    $this->getChirps();
+};  // [tl! add:end]
 
 ?>
 
@@ -284,11 +290,8 @@ new class extends Component
     }
     // [tl! collapse:end]
     #[On('chirp-created')]
-    #[On('chirp-updated')] // [tl! add]
     public function getChirps(): void
     {
-        $this->editing = null; // [tl! add:start]
-        // [tl! add:end]
         $this->chirps = Chirp::with('user')
             ->latest()
             ->get();
@@ -297,12 +300,17 @@ new class extends Component
     public function edit(Chirp $chirp): void
     {
         $this->editing = $chirp;
+
+        $this->getChirps();
     }
     // [tl! add:start]
     #[On('chirp-edit-canceled')]
-    public function cancelEdit(): void
+    #[On('chirp-updated')] // [tl! add]
+    public function disableEditing(): void
     {
         $this->editing = null;
+
+        $this->getChirps();
     } // [tl! add:end]
 }; ?>
 
@@ -357,11 +365,12 @@ new class extends Component
 use App\Models\Chirp;
 use function Livewire\Volt\{on, state};
 
-$getChirps = fn () => $this->chirps = Chirp::with('user')->latest()->get(); // [tl! remove]
-$getChirps = function () { // [tl! add:start]
+$getChirps = fn () => $this->chirps = Chirp::with('user')->latest()->get();
+
+$disableEditing = function () { // [tl! add:start]
     $this->editing = null;
 
-    return $this->chirps = Chirp::with('user')->latest()->get();
+    return $this->getChirps();
 }; // [tl! add:end]
 
 state(['chirps' => $getChirps, 'editing' => null]);
@@ -369,11 +378,15 @@ state(['chirps' => $getChirps, 'editing' => null]);
 on(['chirp-created' => $getChirps]); // [tl! remove]
 on([ // [tl! add:start]
     'chirp-created' => $getChirps,
-    'chirp-updated' => $getChirps,
-    'chirp-edit-canceled' => fn () => $this->editing = null,
+    'chirp-updated' => $disableEditing,
+    'chirp-edit-canceled' => $disableEditing,
 ]); // [tl! add:end]
 
-$edit = fn (Chirp $chirp) => $this->editing = $chirp;
+$edit = function (Chirp $chirp) {
+    $this->editing = $chirp;
+
+    $this->getChirps();
+};
 
 ?>
 

--- a/resources/docs/livewire/editing-chirps.md
+++ b/resources/docs/livewire/editing-chirps.md
@@ -306,7 +306,7 @@ new class extends Component
     // [tl! add:start]
     #[On('chirp-edit-canceled')]
     #[On('chirp-updated')] // [tl! add]
-    public function disableEdit(): void
+    public function disableEditing(): void
     {
         $this->editing = null;
 
@@ -367,7 +367,7 @@ use function Livewire\Volt\{on, state};
 
 $getChirps = fn () => $this->chirps = Chirp::with('user')->latest()->get();
 
-$disableEdit = function () { // [tl! add:start]
+$disableEditing = function () { // [tl! add:start]
     $this->editing = null;
 
     return $this->getChirps();
@@ -378,8 +378,8 @@ state(['chirps' => $getChirps, 'editing' => null]);
 on(['chirp-created' => $getChirps]); // [tl! remove]
 on([ // [tl! add:start]
     'chirp-created' => $getChirps,
-    'chirp-updated' => $disableEdit,
-    'chirp-edit-canceled' => $disableEdit,
+    'chirp-updated' => $disableEditing,
+    'chirp-edit-canceled' => $disableEditing,
 ]); // [tl! add:end]
 
 $edit = function (Chirp $chirp) {

--- a/resources/docs/livewire/editing-chirps.md
+++ b/resources/docs/livewire/editing-chirps.md
@@ -306,7 +306,7 @@ new class extends Component
     // [tl! add:start]
     #[On('chirp-edit-canceled')]
     #[On('chirp-updated')] // [tl! add]
-    public function cancelEdit(): void
+    public function disableEdit(): void
     {
         $this->editing = null;
 
@@ -367,7 +367,7 @@ use function Livewire\Volt\{on, state};
 
 $getChirps = fn () => $this->chirps = Chirp::with('user')->latest()->get();
 
-$cancelEdit = function () { // [tl! add:start]
+$disableEdit = function () { // [tl! add:start]
     $this->editing = null;
 
     return $this->getChirps();
@@ -378,8 +378,8 @@ state(['chirps' => $getChirps, 'editing' => null]);
 on(['chirp-created' => $getChirps]); // [tl! remove]
 on([ // [tl! add:start]
     'chirp-created' => $getChirps,
-    'chirp-updated' => $cancelEdit,
-    'chirp-edit-canceled' => $cancelEdit,
+    'chirp-updated' => $disableEdit,
+    'chirp-edit-canceled' => $disableEdit,
 ]); // [tl! add:end]
 
 $edit = function (Chirp $chirp) {

--- a/resources/docs/livewire/editing-chirps.md
+++ b/resources/docs/livewire/editing-chirps.md
@@ -306,7 +306,7 @@ new class extends Component
     // [tl! add:start]
     #[On('chirp-edit-canceled')]
     #[On('chirp-updated')] // [tl! add]
-    public function disableEditing(): void
+    public function cancelEdit(): void
     {
         $this->editing = null;
 
@@ -367,7 +367,7 @@ use function Livewire\Volt\{on, state};
 
 $getChirps = fn () => $this->chirps = Chirp::with('user')->latest()->get();
 
-$disableEditing = function () { // [tl! add:start]
+$cancelEdit = function () { // [tl! add:start]
     $this->editing = null;
 
     return $this->getChirps();
@@ -378,8 +378,8 @@ state(['chirps' => $getChirps, 'editing' => null]);
 on(['chirp-created' => $getChirps]); // [tl! remove]
 on([ // [tl! add:start]
     'chirp-created' => $getChirps,
-    'chirp-updated' => $disableEditing,
-    'chirp-edit-canceled' => $disableEditing,
+    'chirp-updated' => $cancelEdit,
+    'chirp-edit-canceled' => $cancelEdit,
 ]); // [tl! add:end]
 
 $edit = function (Chirp $chirp) {


### PR DESCRIPTION
This PR are fix editing chirper and add a confirmation pop up when delete a chirper using `wire:confirm`.

Livewire reset the order of chirps when I'm editing a chirp. In this case, I have a lot of chirps. Here's the video.

**Before**

![Before](https://github.com/laravel/bootcamp.laravel.com/assets/11099186/bcffa381-c60b-40d1-9671-bf5c5791e6ee)


The video below is the result of editing chirp has been fixed and add confirmation when delete a chirp.

**After**

![After](https://github.com/laravel/bootcamp.laravel.com/assets/11099186/60707041-2be0-48c7-b59c-349c01cc72b9)

I'm also create a chirper repository in Livewire (class & functional) and it contains a commit of fix editing a chirper.

Livewire Class: https://github.com/kresnasatya/chirper/commit/84d31339e3b1369cd17f48dd45bc35ab2939f3da, https://github.com/kresnasatya/chirper/tree/livewire

Livewire Functional: https://github.com/kresnasatya/chirper/commit/cc1977c266df8ff0b9432dec7fdfafda148c696a, https://github.com/kresnasatya/chirper/tree/livewire-functional