### PR TITLE
Makes diff removed line match previous example

### DIFF
--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -189,7 +189,7 @@ class ChirpController extends Controller
      */
     public function index(): Response
     {
-        return 'Hello, World!';// [tl! remove]
+        return response('Hello, World!');// [tl! remove]
         return Inertia::render('Chirps/Index', [// [tl! add:start]
             //
         ]);// [tl! add:end]


### PR DESCRIPTION
Fixes a continuation error in the inertia path of the bootcamp. The diff initially shows the index method returning a `response` but the diff on the next step shows the index method returning a raw string.

## previous step

<img width="641" alt="image" src="https://github.com/laravel/bootcamp.laravel.com/assets/44616505/46d1c0f5-1ae8-4adb-82f1-e847359be980">

### pre-fix

<img width="638" alt="image" src="https://github.com/laravel/bootcamp.laravel.com/assets/44616505/1dd3e06c-7133-43e8-9006-21f0f0d24c6b">

### post-fix

<img width="640" alt="image" src="https://github.com/laravel/bootcamp.laravel.com/assets/44616505/0ba6ce0f-34fb-4b92-891d-307f10e8cbfc">

