### PR TITLE
Fix Dropdown buttons in darkmode

### DIFF
--- a/resources/docs/inertia/deleting-chirps.md
+++ b/resources/docs/inertia/deleting-chirps.md
@@ -286,7 +286,7 @@ const editing = ref(false);
                         </button>
                     </template>
                     <template #content>
-                        <button class="block w-full px-4 py-2 text-left text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:bg-gray-100 transition duration-150 ease-in-out" @click="editing = true">
+                        <button class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-800 transition duration-150 ease-in-out" @click="editing = true">
                             Edit
                         </button>
                         <DropdownLink as="button" :href="route('chirps.destroy', chirp.id)" method="delete"><!-- [tl! add:start] -->
@@ -356,7 +356,7 @@ export default function Chirp({ chirp }) {
                                 </button>
                             </Dropdown.Trigger>
                             <Dropdown.Content>
-                                <button className="block w-full px-4 py-2 text-left text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:bg-gray-100 transition duration-150 ease-in-out" onClick={() => setEditing(true)}>
+                                <button className="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-800 transition duration-150 ease-in-out" onClick={() => setEditing(true)}>
                                     Edit
                                 </button>
                                 <Dropdown.Link as="button" href={route('chirps.destroy', chirp.id)} method="delete">

--- a/resources/docs/inertia/editing-chirps.md
+++ b/resources/docs/inertia/editing-chirps.md
@@ -106,7 +106,7 @@ const editing = ref(false);// [tl! add:end]
                         </button>
                     </template>
                     <template #content>
-                        <button class="block w-full px-4 py-2 text-left text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:bg-gray-100 transition duration-150 ease-in-out" @click="editing = true">
+                        <button class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-800 transition duration-150 ease-in-out" @click="editing = true">
                             Edit
                         </button>
                     </template>
@@ -175,7 +175,7 @@ export default function Chirp({ chirp }) {
                                 </button>
                             </Dropdown.Trigger>
                             <Dropdown.Content>
-                                <button className="block w-full px-4 py-2 text-left text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:bg-gray-100 transition duration-150 ease-in-out" onClick={() => setEditing(true)}>
+                                <button className="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-800 transition duration-150 ease-in-out" onClick={() => setEditing(true)}>
                                     Edit
                                 </button>
                             </Dropdown.Content>


### PR DESCRIPTION
### Summary

Fix dropdown buttons in darkmode to be the same as Dropdown.Link in [breeze for react](https://github.com/laravel/breeze/blob/v1.26.2/stubs/inertia-react/resources/js/Components/Dropdown.jsx#L78) and [breeze for vue](https://github.com/laravel/breeze/blob/v1.26.2/stubs/inertia-vue-ts/resources/js/Components/DropdownLink.vue#L12)

Ideally, this will be fixed in upstream via allowing for both Inertia's Link and a button as options in the Dropdown component. Will work on that later.

### Screenshots

#### Before
![image](https://github.com/laravel/bootcamp.laravel.com/assets/48773133/6821a700-bc20-4162-90b8-669230ad3c8e)

#### After

![image](https://github.com/laravel/bootcamp.laravel.com/assets/48773133/dea354e1-64e9-4652-948e-4854fda6ba94)
