### PR TITLE
Changed #[Rule] to #[Validate] because it got deprecated: https://liv…

### DIFF
--- a/resources/docs/livewire/editing-chirps.md
+++ b/resources/docs/livewire/editing-chirps.md
@@ -183,7 +183,7 @@ new class extends Component
 {
     public Chirp $chirp; // [tl! add:start]
 
-    #[Rule('required|string|max:255')]
+    #[Validate('required|string|max:255')]
     public string $message = '';
 
     public function mount(): void


### PR DESCRIPTION
*There could be more occourances - I found this while reading the bootcamp:
https://livewire.laravel.com/docs/validation#deprecated-rule-attribute
