### PR TITLE
A property fails due to docs Innertia/laravel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "bootcamp",
+    "name": "bootcamp.laravel.com",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -297,7 +297,7 @@ export default function Index({ auth }) {
     };
 
     return (
-        <AuthenticatedLayout user={auth.user}>
+        <AuthenticatedLayout auth={auth}>
             <Head title="Chirps" />
 
             <div className="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">


### PR DESCRIPTION
I think the user property does not go inside the AuthenticatedLayour in the markdown file creating chirps generates an error and makes it impossible to follow the documentation and then later in the docs itself they change the style.