### PR TITLE
fix React Index.jsx code snippet for creating-chirps

### DIFF
--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -297,7 +297,7 @@ export default function Index({ auth }) {
     };
 
     return (
-        <AuthenticatedLayout auth={auth}>
+        <AuthenticatedLayout auth={auth} user={auth.user}>
             <Head title="Chirps" />
 
             <div className="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">


### PR DESCRIPTION
The AuthenticatedLayout component expects a user prop which was not passed, causing an error for reading an undefined property. Fixes #60 [Link to my comment in #60](https://github.com/laravel/bootcamp.laravel.com/pull/60#issuecomment-1870815700)