### PR TITLE
Revert "A property fails due to docs Innertia/laravel"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "bootcamp.laravel.com",
+    "name": "bootcamp",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -297,7 +297,7 @@ export default function Index({ auth }) {
     };
 
     return (
-        <AuthenticatedLayout auth={auth}>
+        <AuthenticatedLayout user={auth.user}>
             <Head title="Chirps" />
 
             <div className="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">


### PR DESCRIPTION
The PR reverts laravel/bootcamp.laravel.com#60 which incorrectly changed the props passed to the `AuthenticatedLayout` component to not work with current versions of Breeze.
