### PR TITLE
Add note about required PHP version

### DIFF
--- a/resources/docs/blade/installation.md
+++ b/resources/docs/blade/installation.md
@@ -12,6 +12,9 @@ If you have already [installed PHP and Composer on your local machine](https://h
 composer create-project laravel/laravel chirper
 ```
 
+> **Note**
+> You will need a [supported version of PHP](https://www.php.net/supported-versions.php) before continuing. You may check your installation by running the `php -v` command. Alternatively, you may follow the <a href="#docker">instructions for Docker</a>.
+
 After the project has been created, start Laravel's local development server using the Laravel's Artisan CLI serve command:
 
 ```none
@@ -31,6 +34,7 @@ For simplicity, you may use SQLite to store your application's data. To instruct
 DB_CONNECTION=sqlite
 ```
 
+<a name="docker"></a>
 ### Installation via Docker
 
 If you do not have PHP installed locally, you may develop your application using [Laravel Sail](https://laravel.com/docs/sail), a light-weight command-line interface for interacting with Laravel's default Docker development environment, which is compatible with all operating systems. Before we get started, make sure to install [Docker](https://docs.docker.com/get-docker/) for your operating system. For alternative installation methods, check out our full [installation guide](https://laravel.com/docs/installation).

--- a/resources/docs/inertia/installation.md
+++ b/resources/docs/inertia/installation.md
@@ -12,6 +12,9 @@ If you have already [installed PHP and Composer on your local machine](https://h
 composer create-project laravel/laravel chirper
 ```
 
+> **Note**
+> You will need a [supported version of PHP](https://www.php.net/supported-versions.php) before continuing. You may check your installation by running the `php -v` command. Alternatively, you may follow the <a href="#docker">instructions for Docker</a>.
+
 After the project has been created, start Laravel's local development server using the Laravel's Artisan CLI serve command:
 
 ```none
@@ -31,6 +34,7 @@ For simplicity, you may use SQLite to store your application's data. To instruct
 DB_CONNECTION=sqlite
 ```
 
+<a name="docker"></a>
 ### Installation via Docker
 
 If you do not have PHP installed locally, you may develop your application using [Laravel Sail](https://laravel.com/docs/sail), a light-weight command-line interface for interacting with Laravel's default Docker development environment, which is compatible with all operating systems. Before we get started, make sure to install [Docker](https://docs.docker.com/get-docker/) for your operating system. For alternative installation methods, check out our full [installation guide](https://laravel.com/docs/installation).

--- a/resources/docs/livewire/installation.md
+++ b/resources/docs/livewire/installation.md
@@ -12,6 +12,9 @@ If you have already [installed PHP and Composer on your local machine](https://h
 composer create-project laravel/laravel chirper
 ```
 
+> **Note**
+> You will need a [supported version of PHP](https://www.php.net/supported-versions.php) before continuing. You may check your installation by running the `php -v` command. Alternatively, you may follow the <a href="#docker">instructions for Docker</a>.
+
 After the project has been created, start Laravel's local development server using the Laravel's Artisan CLI serve command:
 
 ```none
@@ -31,6 +34,7 @@ For simplicity, you may use SQLite to store your application's data. To instruct
 DB_CONNECTION=sqlite
 ```
 
+<a name="docker"></a>
 ### Installation via Docker
 
 If you do not have PHP installed locally, you may develop your application using [Laravel Sail](https://laravel.com/docs/sail), a light-weight command-line interface for interacting with Laravel's default Docker development environment, which is compatible with all operating systems. Before we get started, make sure to install [Docker](https://docs.docker.com/get-docker/) for your operating system. For alternative installation methods, check out our full [installation guide](https://laravel.com/docs/installation).


### PR DESCRIPTION
If an old version of PHP is installed, then Composer may install old versions of packages which may not work with the instructions in the Bootcamp.

Composer warns about not using the latest version, but it's easy to miss with the output that follows:

![image](https://github.com/laravel/bootcamp.laravel.com/assets/4977161/d0dabc66-8f69-4910-8fc3-4565a33c2696)

Rather than hardcode specific versions in the Bootcamp, which would need to be continually updated. This PR adds a note to encourage users to check that they have a currently supported version of PHP, linking to PHP's supported version documentation.