### PR TITLE
add a missing trait to the inertia guide

### DIFF
--- a/resources/docs/inertia/editing-chirps.md
+++ b/resources/docs/inertia/editing-chirps.md
@@ -199,6 +199,7 @@ We can now update the `update` method on our `ChirpController` class to validate
 namespace App\Http\Controllers;
 
 use App\Models\Chirp;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -206,6 +207,8 @@ use Inertia\Response;
 // [tl! collapse:end]
 class ChirpController extends Controller
 {
+    use AuthorizesRequests;
+
     // [tl! collapse:start]
     /**
      * Display a listing of the resource.

--- a/resources/docs/inertia/editing-chirps.md
+++ b/resources/docs/inertia/editing-chirps.md
@@ -207,8 +207,6 @@ use Inertia\Response;
 // [tl! collapse:end]
 class ChirpController extends Controller
 {
-    use AuthorizesRequests;
-
     // [tl! collapse:start]
     /**
      * Display a listing of the resource.

--- a/resources/docs/inertia/editing-chirps.md
+++ b/resources/docs/inertia/editing-chirps.md
@@ -199,9 +199,9 @@ We can now update the `update` method on our `ChirpController` class to validate
 namespace App\Http\Controllers;
 
 use App\Models\Chirp;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
 // [tl! collapse:end]
@@ -265,7 +265,7 @@ class ChirpController extends Controller
     public function update(Request $request, Chirp $chirp): RedirectResponse// [tl! add]
     {
         //
-        $this->authorize('update', $chirp);// [tl! remove:-1,1 add:start]
+        Gate::authorize('update', $chirp);// [tl! remove:-1,1 add:start]
 
         $validated = $request->validate([
             'message' => 'required|string|max:255',


### PR DESCRIPTION
There's a trait missing in `ChirpController` in [this part](https://laravel.com/docs/11.x/releases#base-controller-class) of the editing chapter. I'm guessing it got lost since the bump to laravel 11 a few days ago. These traits are not part of the base controller anymore: https://laravel.com/docs/11.x/releases#base-controller-class

I'm not that familiar with PHP, so I probably missed something here. Consider this a bug report rather than a complete fix in that case 😊