### PR TITLE
Add Gate facade to Blade tutorial

### DIFF
--- a/resources/docs/blade/deleting-chirps.md
+++ b/resources/docs/blade/deleting-chirps.md
@@ -57,6 +57,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\View\View;
+use Illuminate\Support\Facades\Gate;
 // [tl! collapse:end]
 class ChirpController extends Controller
 {
@@ -106,7 +107,7 @@ class ChirpController extends Controller
      */
     public function edit(Chirp $chirp): View
     {
-        $this->authorize('update', $chirp);
+        Gate::authorize('update', $chirp);
 
         return view('chirps.edit', [
             'chirp' => $chirp,
@@ -118,7 +119,7 @@ class ChirpController extends Controller
      */
     public function update(Request $request, Chirp $chirp): RedirectResponse
     {
-        $this->authorize('update', $chirp);
+        Gate::authorize('update', $chirp);
 
         $validated = $request->validate([
             'message' => 'required|string|max:255',
@@ -136,7 +137,7 @@ class ChirpController extends Controller
     public function destroy(Chirp $chirp): RedirectResponse// [tl! add]
     {
         //
-        $this->authorize('delete', $chirp);// [tl! remove:-1,1 add:start]
+        Gate::authorize('delete', $chirp);// [tl! remove:-1,1 add:start]
 
         $chirp->delete();
 

--- a/resources/docs/blade/deleting-chirps.md
+++ b/resources/docs/blade/deleting-chirps.md
@@ -56,8 +56,8 @@ use App\Models\Chirp;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\View\View;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\View\View;
 // [tl! collapse:end]
 class ChirpController extends Controller
 {

--- a/resources/docs/blade/editing-chirps.md
+++ b/resources/docs/blade/editing-chirps.md
@@ -141,6 +141,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\View\View;
+use Illuminate\Support\Facades\Gate;
 // [tl! collapse:end]
 class ChirpController extends Controller
 {
@@ -192,7 +193,7 @@ class ChirpController extends Controller
     public function edit(Chirp $chirp): View// [tl! add]
     {
         //
-        $this->authorize('update', $chirp);// [tl! remove:-1,1 add:start]
+        Gate::authorize('update', $chirp);// [tl! remove:-1,1 add:start]
 
         return view('chirps.edit', [
             'chirp' => $chirp,
@@ -205,7 +206,7 @@ class ChirpController extends Controller
     public function update(Request $request, Chirp $chirp): RedirectResponse// [tl! add]
     {
         //
-        $this->authorize('update', $chirp);// [tl! remove:-1,1 add:start]
+        Gate::authorize('update', $chirp);// [tl! remove:-1,1 add:start]
 
         $validated = $request->validate([
             'message' => 'required|string|max:255',

--- a/resources/docs/blade/editing-chirps.md
+++ b/resources/docs/blade/editing-chirps.md
@@ -140,8 +140,8 @@ use App\Models\Chirp;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\View\View;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\View\View;
 // [tl! collapse:end]
 class ChirpController extends Controller
 {


### PR DESCRIPTION
The Gate facade appears to be needed due to the new default Controller configuration. I.e. ChirpController->authorize() does not exist by default. This is my first day trying Laravel so I could be way off here.