### PR TITLE
Add highlight use Facade\Gate

### DIFF
--- a/resources/docs/blade/editing-chirps.md
+++ b/resources/docs/blade/editing-chirps.md
@@ -146,10 +146,9 @@ namespace App\Http\Controllers;
 use App\Models\Chirp;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Gate;
+use Illuminate\Http\Response;// [tl! collapse:end]
+use Illuminate\Support\Facades\Gate;// [tl! add]
 use Illuminate\View\View;
-// [tl! collapse:end]
 class ChirpController extends Controller
 {
     // [tl! collapse:start]

--- a/resources/docs/inertia/editing-chirps.md
+++ b/resources/docs/inertia/editing-chirps.md
@@ -207,11 +207,10 @@ namespace App\Http\Controllers;
 
 use App\Models\Chirp;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
+use Illuminate\Http\Request;// [tl! collapse:end]
+use Illuminate\Support\Facades\Gate;// [tl! add]
 use Inertia\Inertia;
 use Inertia\Response;
-// [tl! collapse:end]
 class ChirpController extends Controller
 {
     // [tl! collapse:start]


### PR DESCRIPTION
When I tried to learn the bootcamp flow yesterday, there was a slight shortcoming in the editing section, the chirps use Gate was not highlighted even though it was used. Maybe this can help other people who want to follow that the Gate must be imported. 😁