### PR TITLE
Update notification section to reflect Laravel 11

### DIFF
--- a/resources/docs/notifications-and-events.md
+++ b/resources/docs/notifications-and-events.md
@@ -223,7 +223,7 @@ class SendChirpCreatedNotifications implements ShouldQueue// [tl! add]
 }
 ```
 
-We've marked our listener with the `ShouldQueue` interface, which tells Laravel that the listener should be run in a [queue](https://laravel.com/docs/queues). By default, the "database" queue will be used to process jobs asynchronously; to process the notification run `php artisan queue:work`. However, you may set the queue connnection to "sync" to synchronously process queued items with the current request; `QUEUE_CONNECTION=sync`.
+We've marked our listener with the `ShouldQueue` interface, which tells Laravel that the listener should be run in a [queue](https://laravel.com/docs/queues). By default, the "database" queue will be used to process jobs asynchronously. To begin processing queued jobs, you should run the `php artisan queue:work` Artisan command in your terminal.
 
 We've also configured our listener to send notifications to every user in the platform, except the author of the Chirp. In reality, this might annoy users, so you may want to implement a "following" feature so users only receive notifications for accounts they follow.
 

--- a/resources/docs/notifications-and-events.md
+++ b/resources/docs/notifications-and-events.md
@@ -223,7 +223,7 @@ class SendChirpCreatedNotifications implements ShouldQueue// [tl! add]
 }
 ```
 
-We've marked our listener with the `ShouldQueue` interface, which tells Laravel that the listener should be run in a [queue](https://laravel.com/docs/queues). By default, the "database" queue will be used to process jobs asynchronously; to process the notification run `php artisan queue:work`. However, you may configure a queue worker to process synchronously with the request by using the "sync" driver.
+We've marked our listener with the `ShouldQueue` interface, which tells Laravel that the listener should be run in a [queue](https://laravel.com/docs/queues). By default, the "database" queue will be used to process jobs asynchronously; to process the notification run `php artisan queue:work`. However, you may set the queue connnection to "sync" to synchronously process queued items with the current request; `QUEUE_CONNECTION=sync`.
 
 We've also configured our listener to send notifications to every user in the platform, except the author of the Chirp. In reality, this might annoy users, so you may want to implement a "following" feature so users only receive notifications for accounts they follow.
 

--- a/resources/docs/notifications-and-events.md
+++ b/resources/docs/notifications-and-events.md
@@ -223,7 +223,7 @@ class SendChirpCreatedNotifications implements ShouldQueue// [tl! add]
 }
 ```
 
-We've marked our listener with the `ShouldQueue` interface, which tells Laravel that the listener should be run in a [queue](https://laravel.com/docs/queues). By default, the "sync" queue will be used to process jobs synchronously; however, you may configure a queue worker to process jobs in the background.
+We've marked our listener with the `ShouldQueue` interface, which tells Laravel that the listener should be run in a [queue](https://laravel.com/docs/queues). By default, the "database" queue will be used to process jobs asynchronously; to process the notification run `php artisan queue:work`. However, you may configure a queue worker to process synchronously with the request by using the "sync" driver.
 
 We've also configured our listener to send notifications to every user in the platform, except the author of the Chirp. In reality, this might annoy users, so you may want to implement a "following" feature so users only receive notifications for accounts they follow.
 


### PR DESCRIPTION
The default queue driver in Laravel 11 has changed to `database` instead of `sync`. So the Notifications & Events section wouldn't work if followed, since the queued notification is never handled. One would need to start the worker or change the `QUEUE_CONNECTION` to `sync`