### PR TITLE
Inertia refresh page when receive status 302 from RedirectResponse.

### DIFF
--- a/resources/docs/inertia/showing-chirps.md
+++ b/resources/docs/inertia/showing-chirps.md
@@ -14,7 +14,7 @@ Let's update the `index` method of our `ChirpController` class to pass Chirps fr
 namespace App\Http\Controllers;
 
 use App\Models\Chirp;
-use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\RedirectResponse;// [tl! remove]
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -43,7 +43,8 @@ class ChirpController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request): RedirectResponse// [tl! remove]
+    public function store(Request $request): Response// [tl! add]
     {
         $validated = $request->validate([
             'message' => 'required|string|max:255',

--- a/resources/docs/inertia/showing-chirps.md
+++ b/resources/docs/inertia/showing-chirps.md
@@ -51,7 +51,10 @@ class ChirpController extends Controller
 
         $request->user()->chirps()->create($validated);
 
-        return redirect(route('chirps.index'));
+        return redirect(route('chirps.index'));// [tl! remove]
+        return Inertia::render('Chirps/Index', [// [tl! add:start]
+            'chirps' => Chirp::with('user:id,name')->latest()->get(),// [tl! remove:-1,1 add]
+        ]);// [tl! add:end]
     }
 
     /**

--- a/resources/docs/inertia/showing-chirps.md
+++ b/resources/docs/inertia/showing-chirps.md
@@ -54,7 +54,7 @@ class ChirpController extends Controller
 
         return redirect(route('chirps.index'));// [tl! remove]
         return Inertia::render('Chirps/Index', [// [tl! add:start]
-            'chirps' => Chirp::with('user:id,name')->latest()->get(),// [tl! remove:-1,1 add]
+            'chirps' => Chirp::with('user:id,name')->latest()->get(),
         ]);// [tl! add:end]
     }
 


### PR DESCRIPTION
Inertia refresh page when receive status 302 from RedirectResponse.

Before fix:
![image](https://github.com/laravel/bootcamp.laravel.com/assets/4064979/70776a6e-35b7-4a8f-adc6-782b8a64bd38)

After fix:
![image](https://github.com/laravel/bootcamp.laravel.com/assets/4064979/42422e80-d5df-446b-8e1e-65df10623f94)
