### PR TITLE
Remove invalid `AuthenticatedLayout` props from inertia react docs

### DIFF
--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -293,7 +293,7 @@ export default function Index({ auth }) {
     };
 
     return (
-        <AuthenticatedLayout user={auth.user}>
+        <AuthenticatedLayout>
             <Head title="Chirps" />
 
             <div className="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">

--- a/resources/docs/inertia/showing-chirps.md
+++ b/resources/docs/inertia/showing-chirps.md
@@ -239,7 +239,7 @@ export default function Index({ auth, chirps }) {// [tl! add]
     };
 
     return (
-        <AuthenticatedLayout auth={auth}>
+        <AuthenticatedLayout>
             <Head title="Chirps" />
 
             <div className="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">


### PR DESCRIPTION
This PR removes invalid props from the `AuthenticatedLayout` layout component within the `resources/docs/inertia` React docs.

`creating-chirps.md` shows the `AuthenticatedLayout` layout component having a `user` prop.
`showing-chirps.md` shows the `AuthenticatedLayout`  layout component having an `auth` prop.

The current React prop type on the `AuthenticatedLayout` layout component is `PropsWithChildren<{ header?: ReactNode }>`.
- [Breeze Inertia JavaScript Component](https://github.com/laravel/breeze/blob/2.x/stubs/inertia-react/resources/js/Layouts/AuthenticatedLayout.jsx)
- [Breeze Inertia Typescript Component](https://github.com/laravel/breeze/blob/2.x/stubs/inertia-react-ts/resources/js/Layouts/AuthenticatedLayout.tsx)

If the user chooses to modify the tutorial to use typescript instead of javascript, a ts error is introduced (`resources/Pages/Chirps/Index`):

![image](https://github.com/user-attachments/assets/956f6b1f-6b68-4d94-9946-0aa290dd6d36)

