### PR TITLE
Fix: Pass user details to AuthenticatedLayout component

### DIFF
--- a/resources/docs/inertia/creating-chirps.md
+++ b/resources/docs/inertia/creating-chirps.md
@@ -259,7 +259,7 @@ const form = useForm({
 <template>
     <Head title="Chirps" />
 
-    <AuthenticatedLayout>
+    <AuthenticatedLayout :user="auth.user">
         <div class="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">
             <form @submit.prevent="form.post(route('chirps.store'), { onSuccess: () => form.reset() })">
                 <textarea
@@ -293,7 +293,7 @@ export default function Index({ auth }) {
     };
 
     return (
-        <AuthenticatedLayout>
+        <AuthenticatedLayout user={auth.user}>
             <Head title="Chirps" />
 
             <div className="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">

--- a/resources/docs/inertia/showing-chirps.md
+++ b/resources/docs/inertia/showing-chirps.md
@@ -195,7 +195,7 @@ const form = useForm({
 <template>
     <Head title="Dashboard" />
 
-    <AuthenticatedLayout>
+    <AuthenticatedLayout :user="auth.user">
         <div class="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">
             <form @submit.prevent="form.post(route('chirps.store'), { onSuccess: () => form.reset() })">
                 <textarea
@@ -239,7 +239,7 @@ export default function Index({ auth, chirps }) {// [tl! add]
     };
 
     return (
-        <AuthenticatedLayout>
+        <AuthenticatedLayout user={auth.user}>
             <Head title="Chirps" />
 
             <div className="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">


### PR DESCRIPTION
This pull request fixes an issue where the <AuthenticatedLayout> component was not receiving the user details, causing an error. The user details are now correctly passed to the <AuthenticatedLayout> component.

**Changes Made**
Updated the [creating-chirps.md] file to pass the user details to the <AuthenticatedLayout> component.

I will continue to follow the bootcamp building with Inertia and if any other issues arise, I will fix them and push the changes again.

(I don't know if Vue is passing correctly because I am coding with React, but I think I passed it correctly.